### PR TITLE
Move action count method to engine.

### DIFF
--- a/artist/dna_parser.py
+++ b/artist/dna_parser.py
@@ -83,7 +83,7 @@ class GeneSequencer():
     gene = self.chromo.genes[self.index:end_i]
     self.index = end_i
 
-    action_index = 1 + (_dna_as_int(gene) % self.chromo.graphics_engine.action_class.count())
+    action_index = 1 + (_dna_as_int(gene) % self.chromo.graphics_engine.get_action_count())
     return self.chromo.graphics_engine.get_action(action_index)
 
 

--- a/artist/graphics/actions.py
+++ b/artist/graphics/actions.py
@@ -66,10 +66,6 @@ def _turtle_color_read(fun, field):
 
 
 class TurtleAction(Action):
-  @classmethod
-  def count(cls):
-    return len(cls.__members__)
-
   # Movements
   FORWARD = (ActionType.MOVE, turtle.forward, [_position])
   BACKWARD = (ActionType.MOVE, turtle.backward, [_position])

--- a/artist/graphics/engine.py
+++ b/artist/graphics/engine.py
@@ -20,6 +20,9 @@ class EngineInterface(metaclass=abc.ABCMeta):
   def get_action(self, index):
     return self.action_class(index)
 
+  def get_action_count(self):
+    return len(self.action_class.__members__)
+
 
 class TurtleEngine(EngineInterface):
 


### PR DESCRIPTION
## Description

Move action count method to the graphics engine. This keeps the interface with the graphics code cleaner.  Other classes shouldn't have to dig into details.

## Testing

Ran output on test DNA and visually verified the output image matched.

