### PR TITLE
Add .env.example and virtual display instructions.

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+GOOGLE_APPLICATION_CREDENTIALS="/path/to/your/iam/serice/account.json"
+GOOGLE_CLOUD_PROJECT="artist-2d"

--- a/README.md
+++ b/README.md
@@ -28,9 +28,18 @@ This is a WIP.
 
 1. You will need python (see Pipfile for version) and pip.
 2. You will need to set to create a gcp iam role for your local dev (name it "YOURNAME-local-dev") and download the json secret stuff.
-3. Create a `.env` file that specifies GCP envvars. TODO(kmd): add `example.env` for folks to start from.
+3. Create a `.env` file that specifies GCP envvars.
+   - You can start by copying the example and updating the values. `cp .env.example .env`
 4. `make setup` will handle pipenv fun for you.
 5. Do something to improve this getting started guide!
+
+### Optional setup
+
+1. Run on a virtual display rather than your real display. (Linux)
+  - `sudo apt install xvfb`
+  - `Xvfb :99 -screen 0 1024x768x24 > /dev/null 2>&1 &`
+  - In your local `.env` file, add a line `DISPLAY=":99.0"`.
+  - Run `make test` to see that you no longer see the display.
 
 ## Run
 


### PR DESCRIPTION
## Description

- Add `.env.example` for folks to copy from as a starting point.
- Add readme instructions for setting up and using a virtual display.

## Testing

Followed the instructions and verified `make test` works.
Ran `make run` and verified the image upload to blobstore still looked right.
