### PR TITLE
Treat chromosomes as inverse pairs.

### DIFF
--- a/artist/dna_parser.py
+++ b/artist/dna_parser.py
@@ -3,9 +3,18 @@ import random
 START_SEQUENCE = 'AAA'
 END_SEQUENCE = 'TTT'
 
+INVERSE_MAP = {
+  ord('A'): ord('T'),
+  ord('T'): ord('A'),
+  ord('C'): ord('G'),
+  ord('G'): ord('C'),
+}
+
 
 class Chromosome():
-  def __init__(self, as_str, graphics_engine):
+  def __init__(self, as_str, graphics_engine, inverse=False):
+    if inverse:
+      as_str = as_str.translate(INVERSE_MAP)
     self.str_rep = as_str
     self.graphics_engine = graphics_engine
     self.pre_junk = ''

--- a/artist/painter.py
+++ b/artist/painter.py
@@ -9,21 +9,25 @@ class Painter:
     self.graphics_engine = graphics_engine
     self.chromosomes = []
     for chromosome_str in self.raw_dna.split('\n'):
-      c = dna_parser.Chromosome(chromosome_str.strip(), self.graphics_engine)
-      if c.is_valid():
-        self.chromosomes.append(c)
-    self.max_age = self.chromosomes[0].post_junk_fun()
+      c1 = dna_parser.Chromosome(chromosome_str.strip(), self.graphics_engine)
+      c2 = dna_parser.Chromosome(chromosome_str.strip(), self.graphics_engine, inverse=True)
+      if c1.is_valid() and c2.is_valid():
+        self.chromosomes.append((c1, c2))
+    self.max_age = self.chromosomes[0][0].post_junk_fun()
 
   def still_growing(self):
     return self.age <= self.max_age
 
   def age_up(self):
-    self.age += self.chromosomes[0].pre_junk_fun()
+    self.age += self.chromosomes[0][0].pre_junk_fun()
 
   def paint(self):
-    for c in self.chromosomes:
-      # TODO(kmd): Generate the genes for the inverse side.
-      next_stroke = stroke.Stroke(c.pre_junk_fun, c.post_junk_fun)
-      for g in dna_parser.GeneSequencer(c):
-        next_stroke.add_stroke_action(g)
-      next_stroke.apply()
+    for c1, c2 in self.chromosomes:
+      self.paint_stroke(c1)
+      self.paint_stroke(c2)
+
+  def paint_stroke(self, c):
+    next_stroke = stroke.Stroke(c.pre_junk_fun, c.post_junk_fun)
+    for g in dna_parser.GeneSequencer(c):
+      next_stroke.add_stroke_action(g)
+    next_stroke.apply()


### PR DESCRIPTION
## Description

Treat chromosomes as inverse pairs. This is not only more similar to read DNA which has a pair of two RNA strands, but it also adds more context to the interpretation of the DNA.

## Testing

Ran script, viewed random output.
