### PR TITLE
Fix name.

### DIFF
--- a/voting_api/service.yaml
+++ b/voting_api/service.yaml
@@ -1,7 +1,7 @@
 apiVersion: serving.knative.dev/v1
 kind: Service
 metadata:
-  name: voting_api
+  name: voting-api
 spec:
   template:
     metadata:


### PR DESCRIPTION
## Description

Use dash (`-`) instead of underscore (`_`) in service name to meet requirements.
