### PR TITLE
Set service port

### DIFF
--- a/infra/app/main.tf
+++ b/infra/app/main.tf
@@ -60,18 +60,9 @@ resource "google_cloud_run_v2_service" "storageapi" {
 
     containers {
       image = "${local.image_base}storageapi:${local.storageapi_tag}"
-      # TODO: gunicorn
-      command = ["python", "manage.py", "runserver", "0.0.0.0:8000"]
 
-      startup_probe {
-        tcp_socket {
-          port = 8000
-        }
-      }
-      liveness_probe {
-        http_get {
-          path = "/api/health"
-        }
+      ports {
+        container_port = 8000
       }
 
       env {

--- a/infra/app/variables.tf
+++ b/infra/app/variables.tf
@@ -4,7 +4,7 @@ variable "app_versions" {
     client : "0.1.0",
     votingapi : "0.1.1",
     painterapi : "0.1.0",
-    storageapi : "0.0.0kmddbtest",
+    storageapi : "0.0.0kmddbtestmigrate3",
   }
 
 }


### PR DESCRIPTION
## Description

- Set the service port rather than the various probes. This is needed to access the app as well for all the probes. 
- Don't set the command in infra, instead leverage the entrypoint script which handles DB migration.
- set manually made testing tag for storage API. I'm still debating how I want to manage releases.

## Testing

Deployed.