### PR TITLE
Set up docker auth before running infra.

### DIFF
--- a/.github/workflows/cd.infra.yaml
+++ b/.github/workflows/cd.infra.yaml
@@ -12,6 +12,7 @@ env:
   GOOGLE_APPLICATION_CREDENTIALS: ${{ secrets.GCP_CD }}
   PROJECT: "artist-2d"
   DEPLOY_ENV: "dev"
+  REGION: "us-west1"
 
 
 defaults:
@@ -36,6 +37,10 @@ jobs:
         uses: google-github-actions/setup-gcloud@v2
         with:
           version: '>= 363.0.0'
+
+      - name: Docker auth for GCP Artifact Registry
+        run: |-
+          gcloud auth configure-docker ${{ env.REGION }}-docker.pkg.dev --quiet
 
       - uses: hashicorp/setup-terraform@v3
         with:


### PR DESCRIPTION
## Description

Set up docker auth before running infra. This will allow the terraform to push to the artifact registry.

## Testing

Running CD on PR temp to ensure it works.
 - Commented out the `on` config to restrict to the `main` branch. So it ran on this PR.
 - Verified it ran correctly.
 - Commented the `on` config back in. :)
