### PR TITLE
Remove unneeded trigger. Set app image from registry.

### DIFF
--- a/infra/app/docker.tf
+++ b/infra/app/docker.tf
@@ -19,11 +19,6 @@ resource "docker_image" "app" {
     context = "${path.cwd}/../../${each.key}"
     tag     = ["${local.image_root}/${each.key}:${each.value}"]
   }
-
-  triggers = {
-    # Trigger a build if this value has changed.
-    version_tag = each.value
-  }
 }
 
 resource "docker_registry_image" "app" {

--- a/infra/app/main.tf
+++ b/infra/app/main.tf
@@ -32,7 +32,7 @@ data "google_client_config" "current" {
 }
 
 locals {
-  storageapi_image = tolist(docker_image.app["storageapi"].build)[0].tag[0]
+  storageapi_image = docker_registry_image.app["storageapi"].name
 }
 
 ################################################################


### PR DESCRIPTION
## Description

- Remove unneeded trigger. The new build info (tag `each.value`) should trigger a build when needed. But right now there's some bug where it always rebuilds so we extra don't need a trigger. 😄 
- Set app image from registry. This is a bit simpler of a reference. I also hope that this will cause the service to block on the image being in the registry.

## Testing

locally running `terraform apply` shows only change in the docker image which always change and aren't actually different.
