### PR TITLE
Add Voting API service in terraform.

### DIFF
--- a/infra/app/main.tf
+++ b/infra/app/main.tf
@@ -30,3 +30,8 @@ provider "google-beta" {
 
 data "google_client_config" "current" {
 }
+
+locals {
+  storageapi_image = docker_registry_image.app["storageapi"].name
+  votingapi_image  = docker_registry_image.app["votingapi"].name
+}

--- a/infra/app/networking.tf
+++ b/infra/app/networking.tf
@@ -150,12 +150,6 @@ data "google_cloud_run_service" "client" {
   project  = var.project
 }
 
-data "google_cloud_run_service" "votingapi" {
-  name     = "votingapi"
-  location = var.region
-  project  = var.project
-}
-
 resource "google_cloud_run_domain_mapping" "client" {
   name     = var.domain
   location = data.google_cloud_run_service.client.location

--- a/infra/app/storageapi.tf
+++ b/infra/app/storageapi.tf
@@ -2,12 +2,8 @@
 ## Storage API
 ################################################################
 
-locals {
-  storageapi_image = docker_registry_image.app["storageapi"].name
-}
-
 resource "google_service_account" "storageapi" {
-  account_id   = "cloud-run-service-account"
+  account_id   = "cloud-run-storageapi"
   display_name = "Service account for Cloud Run Storage API"
 }
 

--- a/infra/app/votingapi.tf
+++ b/infra/app/votingapi.tf
@@ -1,0 +1,46 @@
+################################################################
+## Voting API
+################################################################
+
+resource "google_service_account" "votingapi" {
+  account_id   = "cloud-run-votingapi"
+  display_name = "Service account for Cloud Run Voting API"
+}
+
+resource "google_cloud_run_v2_service" "votingapi" {
+  name     = "votingapi"
+  location = var.region
+  ingress  = "INGRESS_TRAFFIC_INTERNAL_LOAD_BALANCER"
+
+  template {
+    containers {
+      name  = "votingapi"
+      image = local.votingapi_image
+
+      ports {
+        container_port = 8000
+      }
+
+      env {
+        name  = "ENV"
+        value = "prod"
+      }
+      env {
+        name  = "GOOGLE_CLOUD_PROJECT"
+        value = var.project
+      }
+
+    }
+    service_account = google_service_account.votingapi.email
+  }
+}
+
+# Allow unauthed requests.
+resource "google_cloud_run_service_iam_binding" "votingapi" {
+  location = google_cloud_run_v2_service.votingapi.location
+  service  = google_cloud_run_v2_service.votingapi.name
+  role     = "roles/run.invoker"
+  members = [
+    "allUsers"
+  ]
+}


### PR DESCRIPTION
## Description

Add Voting API service in terraform. This will be the preferred way to deploying to keep version numbers in a single place and allow services to easily grab into about each other in TF when needed.
