### PR TITLE
Deploy votingapi 0.2.6.

### DIFF
--- a/infra/app/variables.tf
+++ b/infra/app/variables.tf
@@ -2,7 +2,7 @@ variable "app_versions" {
   type = map(string)
   default = {
     client : "0.2.0",
-    votingapi : "0.2.5",
+    votingapi : "0.2.6",
     painterapi : "0.1.0",
     storageapi : "0.0.1",
   }


### PR DESCRIPTION
## Description

Deploy votingapi 0.2.6. to pick up default generation change.
