### PR TITLE
Prefer in-mem db for tests.

### DIFF
--- a/api/app/settings.py
+++ b/api/app/settings.py
@@ -113,7 +113,12 @@ DATABASES = {
     "PASSWORD": os.environ['POSTGRES_PASSWORD'],
   }
 }
-
+# Use in-memory SQLite for testing
+if ENV.lower() == 'test':
+  DATABASES['default'] = {
+    'ENGINE': 'django.db.backends.sqlite3',
+      'NAME': ':memory:'
+  }
 
 # Password validation
 # https://docs.djangoproject.com/en/5.0/ref/settings/#auth-password-validators

--- a/api/docker-compose-test.yml
+++ b/api/docker-compose-test.yml
@@ -1,14 +1,4 @@
-version: '3.9'
-
 services:
-  db-test:
-    image: postgres:15
-    restart: always
-    env_file:
-      - ./.env.test
-    volumes:
-      - postgres_data:/var/lib/postgresql/data
-
   tests:
     build: .
     entrypoint: python manage.py test
@@ -18,8 +8,4 @@ services:
       - /tmp/.X11-unix:/tmp/.X11-unix
     env_file:
       - ./.env.test
-    depends_on:
-      - db-test
-
-volumes:
-  postgres_data:
+    network_mode: host


### PR DESCRIPTION
## Description

If we're testing, use an in-mem db. This is faster. And our current DB usage in tests is simple enough that there's no diff between this and a real db.

## Testing

`make test`
