### PR TITLE
Parse json in middleware for PUT and POST.

### DIFF
--- a/api/api/middleware.py
+++ b/api/api/middleware.py
@@ -1,0 +1,15 @@
+import json
+
+from django.http import HttpResponseBadRequest
+
+
+def json_request(get_response):
+  def middleware(request):
+    if request.method in ('POST', 'PUT') and request.headers['Content-type'] == 'application/json':
+      try:
+        request.post_json = json.loads(request.body)
+      except:
+        return HttpResponseBadRequest('Invalid JSON payload')
+    return get_response(request)
+
+  return middleware

--- a/api/api/tests.py
+++ b/api/api/tests.py
@@ -54,6 +54,7 @@ class TestApi(TestCase):
     response = self.client.post(
       '/api/vote',
       {'artist': test_artist.id},
+      content_type="application/json",
     )
 
     # Validate that it returned success & empty response.

--- a/api/api/views.py
+++ b/api/api/views.py
@@ -32,7 +32,7 @@ def me(request):
 
 @login_required
 def vote(request):
-  artist_id = request.POST['artist']
+  artist_id = request.post_json['artist']
   new_vote = models.Vote.objects.create(
     user=request.user.votinguser,
     artist_id=artist_id,

--- a/api/app/settings.py
+++ b/api/app/settings.py
@@ -80,6 +80,8 @@ MIDDLEWARE = [
   'allauth.account.middleware.AccountMiddleware',
 
   #'django.middleware.clickjacking.XFrameOptionsMiddleware',
+
+  'api.middleware.json_request',
 ]
 
 ROOT_URLCONF = 'app.urls'


### PR DESCRIPTION
## Description

Add middleware to add `post_json` to the request object for all `POST` and `PUT` (and to return Bad Request if not valid json). This will make it simpler for post and put commands to access data.

## Testing

`make test`

Run locally and curled:

1. `make run`
2. `curl -i 'http://localhost:8000/api/vote'   -H 'Content-Type: application/json'   -H 'Cookie: [copy cookie from browser]'  -X POST   -d '{"artist":"0427b526-d632-41a1-b995-1b07a24befba"}'`




